### PR TITLE
修复了从satck弹出元素后，stack保存元素的数组依然持有对弹出元素的引用引起的内存泄漏。元素从栈顶弹出后将其置为null，可以被JV…

### DIFF
--- a/src/main/java/com/github/hcsp/Stack.java
+++ b/src/main/java/com/github/hcsp/Stack.java
@@ -21,7 +21,9 @@ public class Stack {
         if (size == 0) {
             throw new EmptyStackException();
         }
-        return elements[--size];
+        Object old = elements[size - 1];
+        elements[--size] = null;
+        return old;
     }
 
     /**


### PR DESCRIPTION
…M的GC回收掉

<!--- 你要打开的这个Pull request(PR)的类型是？默认是题目解答，如果你正在修复当前的仓库的缺陷，请选择对应的类型 -->

- [x] 这个PR解答了当前仓库中的题目（机器人会自动判题并合并当前PR）
- [ ] 这个PR修复了当前仓库中的一些代码缺陷（机器人不会判题，而是由管理员来处理当前PR）

