### PR TITLE
调用stack的pop方法后虽然返回了栈顶元素，但是并没有从栈中将其删除

### DIFF
--- a/src/main/java/com/github/hcsp/Stack.java
+++ b/src/main/java/com/github/hcsp/Stack.java
@@ -21,7 +21,9 @@ public class Stack {
         if (size == 0) {
             throw new EmptyStackException();
         }
-        return elements[--size];
+        Object result = elements[size - 1];
+        elements[--size] = null;
+        return result;
     }
 
     /**


### PR DESCRIPTION
<!--- 你要打开的这个Pull request(PR)的类型是？默认是题目解答，如果你正在修复当前的仓库的缺陷，请选择对应的类型 -->

- [x] 这个PR解答了当前仓库中的题目（机器人会自动判题并合并当前PR）
- [ ] 这个PR修复了当前仓库中的一些代码缺陷（机器人不会判题，而是由管理员来处理当前PR）

64m的内存被HugeObject占了95%
![image](https://user-images.githubusercontent.com/33724768/74720744-3740d800-5271-11ea-83b8-6d51625fd656.png)

![image](https://user-images.githubusercontent.com/33724768/74720835-5a6b8780-5271-11ea-90fb-c9dc4c1857f5.png)
